### PR TITLE
Substitute strncpy with strlcpy (testing)

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -4,7 +4,7 @@ CFLAGS =-std=gnu99 -D_FILE_OFFSET_BITS=64 -DENABLE_SSL -DENABLE_IPV6 -Wall -Wfat
 #CFLAGS += -DHOSTNAME_VALIDATION
 #CFLAGS += -DDISABLE_SSL_V3
 #CFLAGS += -DDEBUG
-LIBS = -lssl -lcrypto -lpthread
+LIBS = -lssl -lcrypto -lpthread -lbsd
 PROG = xdccget
 
 SRCS = xdccget.c config.c helper.c argument_parser.c libircclient-src/libircclient.c sds.c dirs.c file.c hashing_algo.c

--- a/libircclient-src/colors.c
+++ b/libircclient-src/colors.c
@@ -46,7 +46,7 @@ static inline void libirc_colorparser_addorcat(char ** destline, unsigned int * 
     unsigned int len = strlen(str);
 
     if (*destline) {
-        strncpy(*destline, str, len);
+        strlcpy(*destline, str, len);
         *destline += len;
     }
     else

--- a/libircclient-src/colors.c
+++ b/libircclient-src/colors.c
@@ -13,6 +13,7 @@
  */
 
 #include <ctype.h>
+#include <string.h>
 
 #define LIBIRC_COLORPARSER_BOLD			(1<<1)
 #define LIBIRC_COLORPARSER_UNDERLINE            (1<<2)

--- a/libircclient-src/colors.c
+++ b/libircclient-src/colors.c
@@ -13,7 +13,7 @@
  */
 
 #include <ctype.h>
-#include <string.h>
+#include <bsd/string.h>
 
 #define LIBIRC_COLORPARSER_BOLD			(1<<1)
 #define LIBIRC_COLORPARSER_UNDERLINE            (1<<2)

--- a/libircclient-src/irc_line_parser.c
+++ b/libircclient-src/irc_line_parser.c
@@ -1,5 +1,6 @@
 #include "session.h"
 #include "irc_line_parser.h"
+#include <bsd/string.h>
 
 #include "../helper.h"
 #include "irc_parser.h"
@@ -53,7 +54,7 @@ void free_parser_result (irc_parser *parser) {
 
 static inline char* calloc_and_copy_string(const char *string, size_t len) {
     char *result = Calloc(len+1, sizeof(char));
-    strncpy(result, string, len);
+    strlcpy(result, string, len);
     return result;
 }
 

--- a/libircclient-src/libircclient.c
+++ b/libircclient-src/libircclient.c
@@ -22,6 +22,7 @@
 #include "libircclient.h"
 #include "session.h"
 #include "../helper.h"
+#include <string.h>
 
 #include "utils.c"
 #include "fd_watcher.c"

--- a/libircclient-src/libircclient.c
+++ b/libircclient-src/libircclient.c
@@ -22,7 +22,7 @@
 #include "libircclient.h"
 #include "session.h"
 #include "../helper.h"
-#include <string.h>
+#include <bsd/string.h>
 
 #include "utils.c"
 #include "fd_watcher.c"

--- a/libircclient-src/libircclient.c
+++ b/libircclient-src/libircclient.c
@@ -608,7 +608,7 @@ int irc_send_raw(irc_session_t * session, const char * format, ...) {
         return 1;
     }
 
-    strncpy(session->outgoing_buf + session->outgoing_offset, buf, strlen(buf));
+    strlcpy(session->outgoing_buf + session->outgoing_offset, buf, strlen(buf));
     session->outgoing_offset += strlen(buf);
     session->outgoing_buf[session->outgoing_offset++] = 0x0D;
     session->outgoing_buf[session->outgoing_offset++] = 0x0A;

--- a/xdccget.c
+++ b/xdccget.c
@@ -14,6 +14,7 @@
 #include "file.h"
 #include "hashing_algo.h"
 #include "config.h"
+#include <bsd/string.h>
 
 #define NICKLEN 20
 
@@ -157,14 +158,14 @@ static sds extractMD5 (const char *string) {
     char *md5sum = strstr(string, "md5sum");
 
     if (md5sum != NULL) {
-        strncpy(md5ChecksumString, md5sum+8, MD5_STR_SIZE);
+        strlcpy(md5ChecksumString, md5sum+8, MD5_STR_SIZE);
         return sdsnew(md5ChecksumString);
     }
 
     md5sum = strstr(string, "MD5");
 
     if (md5sum != NULL) {
-        strncpy(md5ChecksumString, md5sum+4, MD5_STR_SIZE);
+        strlcpy(md5ChecksumString, md5sum+4, MD5_STR_SIZE);
         return sdsnew(md5ChecksumString);
     }
 


### PR DESCRIPTION
To resolve compiler security warning. libbsd-dev(el) needed to compile now.
Compiled and tested. Did not work.