### PR TITLE
Substitute strncpy with memcpy (colors.c, libircclient.c)

### DIFF
--- a/libircclient-src/colors.c
+++ b/libircclient-src/colors.c
@@ -46,7 +46,7 @@ static inline void libirc_colorparser_addorcat(char ** destline, unsigned int * 
     unsigned int len = strlen(str);
 
     if (*destline) {
-        strncpy(*destline, str, len);
+        memcpy(*destline, str, len);
         *destline += len;
     }
     else

--- a/libircclient-src/libircclient.c
+++ b/libircclient-src/libircclient.c
@@ -608,7 +608,7 @@ int irc_send_raw(irc_session_t * session, const char * format, ...) {
         return 1;
     }
 
-    strncpy(session->outgoing_buf + session->outgoing_offset, buf, strlen(buf));
+    memcpy(session->outgoing_buf + session->outgoing_offset, buf, strlen(buf));
     session->outgoing_offset += strlen(buf);
     session->outgoing_buf[session->outgoing_offset++] = 0x0D;
     session->outgoing_buf[session->outgoing_offset++] = 0x0A;


### PR DESCRIPTION
Substitute strncpy with memcpy, if strlen(buf) is used to properly fix compiler warnings like
"warning: 'strncpy' output truncated before terminating nul copying X bytes from a string..."